### PR TITLE
fix js error with contao 4.4 and advanced classes bundle

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -21,37 +21,22 @@ if (TL_MODE == 'BE')
 	if(\Input::get('id') && \Input::get('do') == 'Videohandbuch') // Detailseite
 	{
 		// jQuery no conflict
-		if (isset($GLOBALS['TL_JAVASCRIPT']) && is_array($GLOBALS['TL_JAVASCRIPT']))
+		if(!isset($GLOBALS['TL_JAVASCRIPT']['jquery'])) $GLOBALS['TL_JAVASCRIPT']['jquery'] = 'assets/jquery/js/jquery.min.js||static';
+        	if(!isset($GLOBALS['TL_JAVASCRIPT']['jquery-noconflict'])) $GLOBALS['TL_JAVASCRIPT']['jquery-noconflict'] = 'system/modules/contao_academy_client/assets/jquery.noconflict.js||static';
+		
+		//Check Contao 4
+		if (version_compare(VERSION, '4.4', '<'))
 		{
-			$arrAppendJs = $GLOBALS['TL_JAVASCRIPT'];
-			$GLOBALS['TL_JAVASCRIPT'] = array();
+		    // Code für Contao 3.5
+		    $GLOBALS['TL_JAVASCRIPT'][] = 'assets/jquery/colorbox/' . COLORBOX . '/js/colorbox.min.js||static';
+		    $GLOBALS['TL_CSS'][] = 'assets/jquery/colorbox/' . COLORBOX . '/css/colorbox.min.css||static';
 		}
 		else
 		{
-			$arrAppendJs = array();
-			$GLOBALS['TL_JAVASCRIPT'] = array();
+		    // Code für Versionen ab 4.4
+		    $GLOBALS['TL_JAVASCRIPT'][] = 'assets/colorbox/js/colorbox.min.js||static';
+		    $GLOBALS['TL_CSS'][] = 'assets/colorbox/css/colorbox.min.css||static';
 		}
-		array_unshift($GLOBALS['TL_JAVASCRIPT'], 'system/modules/contao_academy_client/assets/jquery.noconflict.js');
-		
-		//Check Contao 4
-        if (version_compare(VERSION, '4.4', '<'))
-        {
-            // Code für Contao 3.5
-            $jquery_src = 'assets/jquery/core/' . JQUERY . '/jquery.min.js';
-            $GLOBALS['TL_JAVASCRIPT'][] = 'assets/jquery/colorbox/' . COLORBOX . '/js/colorbox.min.js';
-            $GLOBALS['TL_CSS'][] = 'assets/jquery/colorbox/' . COLORBOX . '/css/colorbox.min.css||static';
-        }
-        else
-        {
-            // Code für Versionen ab 4.4
-            $jquery_src = 'assets/jquery/js/jquery.min.js||static';
-            $GLOBALS['TL_JAVASCRIPT'][] = 'assets/colorbox/js/colorbox.min.js';
-            $GLOBALS['TL_CSS'][] = 'assets/colorbox/css/colorbox.min.css||static';
-        }
-		
-		
-		//
-		array_unshift($GLOBALS['TL_JAVASCRIPT'], $jquery_src);
 	}
 }
 


### PR DESCRIPTION
If you use contao 4.4 and the advanced classes bundle (which is also used in the themes from contao-themes.net) you get a javascript error and it is not possible to open the videos. Because the advanced classes bundle adds also jquery and jquery-noconflict.

I have tested it with contao 4.4 and contao 4.9 (with and without the advanced classes bundle) and it works now.